### PR TITLE
Fix for "rawRID"s that do not need to be truncated

### DIFF
--- a/impdump.py
+++ b/impdump.py
@@ -28,8 +28,9 @@ from framework.win32.dshashdump import get_syskey,ds_decrypt_pek,ds_decrypt_sing
 
 # manually decrypt a single hash
 def decUserHash(bootkey,rawPekKey,user,rawRID,rawLMhash,rawNTLMhash):
-
-    rid = int(rawRID[48:],16)
+    
+    # "rawRID" may already be the RID, or the full SID - if latter is true, truncate
+    rid = int(rawRID,16) if len(rawRID)==8 else int(rawRID[48:],16)
     
     encPEK = unhexlify(rawPekKey[16:])
     pek = ds_decrypt_pek(bootkey, encPEK)
@@ -67,7 +68,8 @@ def decUserHash(bootkey,rawPekKey,user,rawRID,rawLMhash,rawNTLMhash):
 # decrypt user hash histories
 def decUserHashHistory(bootkey, rawPekKey, user, rawRID, rawLMhashHistory, rawNTLMhashHistory):
 
-    rid = int(rawRID[48:],16)
+    # "rawRID" may already be the RID, or the full SID - if latter is true, truncate
+    rid = int(rawRID,16) if len(rawRID)==8 else int(rawRID[48:],16)
     
     encPEK = unhexlify(rawPekKey[16:])
     pek = ds_decrypt_pek(bootkey, encPEK)


### PR DESCRIPTION
Adds a conditional that prevents errors when esenutl.py returns an RID instead of the expected SID.

esenutl.py usually returns ATTr589970 (the "rawRID") as a full-length SID, but sometimes an 8 character string which is just the RID. This resulted in errors for some Windows domains because it truncated to blank strings, which couldn't convert to integers. This patch checks whether the truncation is needed.
